### PR TITLE
Update cbindgen dependency

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -28,4 +28,4 @@ default = []
 ffi-headers = ["cbindgen"]
 
 [build-dependencies]
-cbindgen = { version = "0.4.3", optional = true }
+cbindgen = { version = "0.5.2", optional = true }


### PR DESCRIPTION
0.5.2 drops the 0.5.x nightly dependency, so start using it.