### PR TITLE
Add support for Fallout 4's Ultra High Resolution DLC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Version numbers are shared between libloadorder and libloadorder-ffi. This
 changelog does not include libloadorder-ffi changes.
 
+## [?] - 2018-??-??
+
+### Added
+
+- Fallout 4's Ultra High Resolution DLC plugin is now recognised as always
+  being active if installed.
+
 ## [11.4.0] - 2018-06-24
 
 ### Changed

--- a/ffi/tests/ffi.c
+++ b/ffi/tests/ffi.c
@@ -119,7 +119,7 @@ void test_lo_get_implicitly_active_plugins() {
   unsigned int return_code = lo_get_implicitly_active_plugins(handle, &plugins, &num_plugins);
 
   assert(return_code == 0);
-  assert(num_plugins == 7);
+  assert(num_plugins == 8);
   assert(strcmp(plugins[0], "Fallout4.esm") == 0);
   assert(strcmp(plugins[4], "DLCworkshop02.esm") == 0);
   lo_free_string_array(plugins, num_plugins);

--- a/ffi/tests/ffi.cpp
+++ b/ffi/tests/ffi.cpp
@@ -122,7 +122,7 @@ void test_lo_get_implicitly_active_plugins() {
   unsigned int return_code = lo_get_implicitly_active_plugins(handle, &plugins, &num_plugins);
 
   assert(return_code == 0);
-  assert(num_plugins == 7);
+  assert(num_plugins == 8);
   assert(strcmp(plugins[0], "Fallout4.esm") == 0);
   assert(strcmp(plugins[4], "DLCworkshop02.esm") == 0);
   lo_free_string_array(plugins, num_plugins);

--- a/src/game_settings.rs
+++ b/src/game_settings.rs
@@ -70,6 +70,7 @@ const FALLOUT4_HARDCODED_PLUGINS: &[&str] = &[
     "DLCworkshop02.esm",
     "DLCworkshop03.esm",
     "DLCNukaWorld.esm",
+    "DLCUltraHighResolution.esm",
 ];
 
 const FALLOUT4VR_HARDCODED_PLUGINS: &[&str] = &["Fallout4.esm", "Fallout4_VR.esm"];
@@ -703,6 +704,7 @@ mod tests {
             "DLCworkshop02.esm",
             "DLCworkshop03.esm",
             "DLCNukaWorld.esm",
+            "DLCUltraHighResolution.esm",
         ];
         assert_eq!(plugins, settings.implicitly_active_plugins());
 
@@ -776,6 +778,7 @@ mod tests {
             "DLCworkshop02.esm",
             "DLCworkshop03.esm",
             "DLCNukaWorld.esm",
+            "DLCUltraHighResolution.esm",
             "ccBGSFO4001-PipBoy(Black).esl",
             "ccBGSFO4002-PipBoy(Blue).esl",
             "ccBGSFO4003-PipBoy(Camo01).esl",


### PR DESCRIPTION
Mod Organizer, Wrye Bash, and xEdit special case this DLC, and it is mentioned in `Fallout4.exe` (though I'm not skilled enough to say anything further about how `Fallout4.exe` handles it).